### PR TITLE
Chapter09 - Set polarbookshop as standard docker repo

### DIFF
--- a/Chapter09/09-begin/polar-deployment/docker/docker-compose.yml
+++ b/Chapter09/09-begin/polar-deployment/docker/docker-compose.yml
@@ -6,7 +6,8 @@ services:
   catalog-service:
     depends_on:
       - polar-postgres-catalog
-    image: "<your_dockerhub_username>/catalog-service:0.0.1-SNAPSHOT"
+    # optional replace polarbookshop by <your_dockerhub_username>
+    image: "polarbookshop/catalog-service:0.0.1-SNAPSHOT"
     container_name: "catalog-service"
     ports:
       - 9001:9001
@@ -23,7 +24,8 @@ services:
   order-service:
     depends_on:
       - polar-postgres-order
-    image: "<your_dockerhub_username>/order-service:0.0.1-SNAPSHOT"
+    # optional replace polarbookshop by <your_dockerhub_username>
+    image: "polarbookshop/order-service:0.0.1-SNAPSHOT"
     container_name: "order-service"
     ports:
       - 9002:9002


### PR DESCRIPTION
## Problem

When following the steps in the book with as start begin chapter 9, I got error when running the docker-compose commands. Problem was caused by the user have to set the right docker repo. 

## suggestion
Since for the begin of this chapter names are fixed, why not fix the docker repo name as well.