### PR TITLE
Run source scan after build

### DIFF
--- a/Chapter03/03-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter03/03-end/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter04/04-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter04/04-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter04/04-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter04/04-end/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter04/04-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter04/04-end/config-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-begin/config-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-end/catalog-service-jpa/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-end/catalog-service-jpa/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-end/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-end/config-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-intermediate/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-intermediate/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter05/05-intermediate/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter05/05-intermediate/config-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter06/06-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter06/06-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter06/06-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter06/06-begin/config-service/.github/workflows/commit-stage.yml
@@ -17,6 +17,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -29,7 +33,3 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build

--- a/Chapter06/06-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter06/06-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/Chapter06/06-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter06/06-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/Chapter07/07-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter07/07-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/Chapter07/07-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter07/07-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/Chapter07/07-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter07/07-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter07/07-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter07/07-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter08/08-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter08/08-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter08/08-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter08/08-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter08/08-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter08/08-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter08/08-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter08/08-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter08/08-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter08/08-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter09/09-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter09/09-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-intermediate/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-intermediate/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-intermediate/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-intermediate/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-intermediate/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-intermediate/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-intermediate/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-intermediate/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter10/10-intermediate/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter10/10-intermediate/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-begin/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-begin/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter11/11-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter11/11-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-begin/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-begin/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter12/12-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter12/12-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-begin/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-begin/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter13/13-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter13/13-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-begin/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-begin/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter14/14-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter14/14-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-begin/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-begin/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter15/15-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter15/15-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-begin/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-begin/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-begin/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-begin/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-begin/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-begin/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-begin/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-begin/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-begin/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-begin/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-end/catalog-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-end/config-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-end/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-end/edge-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-end/order-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/Chapter16/16-end/quote-function/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/quote-function/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   native:
     name: Build and Test (Native)
     runs-on: ubuntu-22.04

--- a/Chapter16/16-end/quote-service/.github/workflows/commit-stage.yml
+++ b/Chapter16/16-end/quote-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   native:
     name: Build and Test (Native)
     runs-on: ubuntu-22.04

--- a/PolarBookshop/catalog-service/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/catalog-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/PolarBookshop/config-service/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/config-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/PolarBookshop/dispatcher-service/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/dispatcher-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/PolarBookshop/edge-service/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/edge-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/PolarBookshop/order-service/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/order-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
       - name: Validate Kubernetes manifests
         uses: stefanprodan/kube-tools@v1
         with:

--- a/PolarBookshop/quote-function/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/quote-function/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   native:
     name: Build and Test (Native)
     runs-on: ubuntu-22.04

--- a/PolarBookshop/quote-service/.github/workflows/commit-stage.yml
+++ b/PolarBookshop/quote-service/.github/workflows/commit-stage.yml
@@ -22,6 +22,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: gradle
+      - name: Build, unit tests and integration tests
+        run: |
+          chmod +x gradlew
+          ./gradlew build
       - name: Code vulnerability scanning
         uses: anchore/scan-action@v3
         id: scan
@@ -34,10 +38,6 @@ jobs:
         if: success() || failure()
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
-      - name: Build, unit tests and integration tests
-        run: |
-          chmod +x gradlew
-          ./gradlew build
   native:
     name: Build and Test (Native)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Grype can only scan a Java application source code if all the dependencies have already been fetched and available as JAR files. In the "commit-stage.yml" workflow, we need to fix the sequence of actions so that we build the app first and scan the source code afterwards.

Fixes gh-38